### PR TITLE
Update import for `reduce` function

### DIFF
--- a/spark_stratifier/stratifier.py
+++ b/spark_stratifier/stratifier.py
@@ -10,6 +10,7 @@ from pyspark.ml.tuning import CrossValidator, CrossValidatorModel
 from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaParams
 from pyspark.sql.functions import rand
+from functools import reduce
 
 class StratifiedCrossValidator(CrossValidator):
   def stratify_data(self, dataset):


### PR DESCRIPTION
In Python 3, [reduce](https://docs.python.org/3/library/functools.html#functools.reduce) was moved to `functools`. 
This import avoids error when calling `reduce` on line 51.